### PR TITLE
カウントダウン終了時、次のカウントダウン時間が5分なのか25分なのか判別してタイマーを実行させる

### DIFF
--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -8,7 +8,7 @@ const Countdown = () => {
   const restTime = 5 * 60 * 1000;
 
   //作業時間（25分）からカウントダウンを始める
-  const [remainingTimeMs, setRemainingTimeMs] = useState(25 * 60 * 1000);
+  const [remainingTimeMs, setRemainingTimeMs] = useState(workTime);
   const timerRef = useRef(0);
 
   const startTimer = () => {

--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -4,6 +4,9 @@ import { useRef } from 'react';
 
 const Countdown = () => {
 
+  const workTime = 25 * 60 * 1000;
+  const restTime = 5 * 60 * 1000;
+
   //作業時間（25分）からカウントダウンを始める
   const [remainingTimeMs, setRemainingTimeMs] = useState(25 * 60 * 1000);
   const timerRef = useRef(0);

--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -24,6 +24,8 @@ const Countdown = () => {
   useEffect(() => {
     if (remainingTimeMs === 0) {
       finish_sound.play();
+
+      //稼働中のタイマーを停止する
       clearInterval(timerRef.current);
 
       //次のタイマーの時間を設定する

--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -25,7 +25,11 @@ const Countdown = () => {
     if (remainingTimeMs === 0) {
       finish_sound.play();
       clearInterval(timerRef.current);
-      setRemainingTimeMs(5 * 60 * 1000);
+
+      //次のタイマーの時間を設定する
+      const nextTimeMs = isWorkMode ? restTime : workTime;
+      setRemainingTimeMs(nextTimeMs);
+
       startTimer();
     };
   },[remainingTimeMs]);

--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -9,6 +9,7 @@ const Countdown = () => {
 
   //作業時間（25分）からカウントダウンを始める
   const [remainingTimeMs, setRemainingTimeMs] = useState(workTime);
+  const [isWorkMode, setIsWorkMode] = useState(true);
   const timerRef = useRef(0);
 
   const startTimer = () => {
@@ -32,6 +33,7 @@ const Countdown = () => {
   return (
     <div className="Countdown">
       <p>{ remainingTimeMs }</p>
+      <p>{ isWorkMode ? '作業中' : '休憩中' }</p>
       <button onClick={startTimer}>スタート</button>
     </div>
   );

--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -30,6 +30,9 @@ const Countdown = () => {
       const nextTimeMs = isWorkMode ? restTime : workTime;
       setRemainingTimeMs(nextTimeMs);
 
+      //作業フラグを切り替える
+      setIsWorkMode((prev) => !prev);
+
       startTimer();
     };
   },[remainingTimeMs]);


### PR DESCRIPTION
### 概要
カウントダウン終了時、次のカウントダウン時間が5分なのか25分なのか判別してタイマーを実行させる
close #5 

---
### 背景・目的
作業時間25分⇔休憩時間5分を繰り返すタイマーを作成するため、次のサイクルが作業時間なのか休憩時間なのか判別する必要があるから。

---
### やったこと
- [x] `workTime`変数（25分をミリ秒換算）と`restTime`変数（5分をミリ秒換算）を定義
- [x] ハードコードしていた作業時間を、`workTime`で置き換え
- [x] `isWorkMode`という`state`を定義する。デフォルトは`true`とする
- [x] wassupdee/pomodoro_timer_app_new#4 で`remainingTimeMs`にミリ秒を設定する際、`if`文を用いて、`isWorkMode`の真偽を判別する
- [x] 真の場合、次のサイクルは休憩時間になるので、5分分（ミリ秒単位）を`remainingTimeMs`にセットする
- [x] 偽の場合、次のサイクルは作業時間になるので、25分分（ミリ秒単位）を`remainingTimeMs`にセットする
- [x] UIに、作業時間か休憩時間かを表示させる

---
### UIスクショ
[![Image from Gyazo](https://i.gyazo.com/102dd3657412066541e8a01f184cfbbd.gif)](https://gyazo.com/102dd3657412066541e8a01f184cfbbd)
**動作確認のため、作業時間と休憩時間を短く設定**

---
### 対応しないこと
- 作業時間と休憩時間終了時の音の出し分けは、別のイシューで取り組む

---
### 補足