### PR TITLE
リセットボタンを押すと、カウントダウンをリセットする（25分の状態に戻して停止する）

### DIFF
--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -54,6 +54,7 @@ const Countdown = () => {
       <p>{ isWorkMode ? '作業中' : '休憩中' }</p>
       <button onClick={startTimer}>スタート</button>
       <button onClick={stopTimer}>ストップ</button>
+      <button onClick={resetTimer}>リセット</button>
     </div>
   );
 };

--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -23,6 +23,11 @@ const Countdown = () => {
     clearInterval(timerRef.current)
   };
 
+  const resetTimer = () => {
+    clearInterval(timerRef.current)
+    setRemainingTimeMs(workTime);
+  };
+
   const finish_sound = new Audio("/finish_whistle.wav");
 
   useEffect(() => {


### PR DESCRIPTION
### 概要
リセットボタンを押すと、カウントダウンをリセットする（25分の状態に戻して停止する）
close #7 

---
### 背景・目的
カウントダウンをリセットさせる機能を実装するため

---
### タスク
- [x] `resetTimer`関数を定義する
  - [x] `remainingTimeMs`を25分分（ミリ秒単位）にセットする
  - [x] timerを止める
- [x] クリックされると`resetTimer`関数を発火させるボタンをつくる

---
### UIスクショ
[![Image from Gyazo](https://i.gyazo.com/7bfb244351d801c15a9bbd42280d88a6.gif)](https://gyazo.com/7bfb244351d801c15a9bbd42280d88a6)

---
### 対応しないこと
- リセット状態（初期状態）では、UIに「作業中」の文字を表示しないようにする。別イシューで対応します。

---
### 補足
なし