### PR TITLE
カウントダウン実行中は、スタートボタンを無効にする

### DIFF
--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -21,6 +21,9 @@ const Countdown = () => {
   //カウントダウンタイマーのIDを保持する
   const timerRef = useRef(0);
 
+  //カウントダウン実行中のフラグ(実行中はスタートボタンを無効化するため)
+  const [isCountingDown, setIsCountingDown] = useState(false);
+
   //カウントダウン終了時のチャイム
   const sound = {
     finishWork: new Audio("/finishWorkWhistle.wav"),
@@ -33,15 +36,18 @@ const Countdown = () => {
       setRemainingTimeMs((prev) => prev - 1000)
     }, 1000);
     timerRef.current = timerId;
+    setIsCountingDown(true);
   };
 
   const stopTimer = () => {
-    clearInterval(timerRef.current)
+    clearInterval(timerRef.current);
+    setIsCountingDown(false);
   };
 
   const resetTimer = () => {
     clearInterval(timerRef.current)
     setRemainingTimeMs(workTime);
+    setIsCountingDown(false);
   };
 
   //カウントダウン終了時の処理
@@ -71,7 +77,7 @@ const Countdown = () => {
     <div className="Countdown">
       <p>{ formattedMins } : { formattedSecs  }</p>
       <p>{ isWorkMode ? '作業中' : '休憩中' }</p>
-      <button onClick={startTimer}>スタート</button>
+      <button onClick={startTimer} disabled={ isCountingDown }>スタート</button>
       <button onClick={stopTimer}>ストップ</button>
       <button onClick={resetTimer}>リセット</button>
     </div>


### PR DESCRIPTION
### 概要
カウントダウン実行中は、スタートボタンを無効にする
close #18 

---
### 背景・目的
複数のカウントダウンタイマーを同時に実行させないため

---
### タスク
- [x] `isCountingDown`という`state`を定義する（デフォルトは`false`）
- [x] `isCountingDown`が真の場合、スタートボタンを`disabled`にする
- [x] カウントダウン開始時に、`isCountingDown`を真にする
- [x] カウントダウン停止時に、`isCountingDown`を偽にする
- [x] カウントダウンリセット時に、`isCountingDown`を偽にする

---
### UIスクショ
[![Image from Gyazo](https://i.gyazo.com/898cb6e3ab64dd261381d67faf41f555.gif)](https://gyazo.com/898cb6e3ab64dd261381d67faf41f555)

---
### 補足
- カウントダウン実行⇔停止で、ボタンを再レンダリングする必要があったため、`state`でカウントダウン実行中を判別するフラグを定義しました