### PR TITLE
カウントダウン開始前（初期状態）では、「作業中」の文字を表示しないようにする

### DIFF
--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -42,6 +42,7 @@ const Countdown = () => {
     }, 1000);
     timerRef.current = timerId;
     setIsCountingDown(true);
+    setCountdownMode((prev) => prev !== MODES.WORK ? MODES.WORK : MODES.REST);
   };
 
   const stopTimer = () => {

--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -16,7 +16,12 @@ const Countdown = () => {
   const formattedMins = remainingTimeMins < 10 ? "0" + remainingTimeMins : remainingTimeMins;
   const formattedSecs = remainingTimeSecs < 10 ? "0" + remainingTimeSecs : remainingTimeSecs;
 
-  const [isWorkMode, setIsWorkMode] = useState(true);
+  const MODES = {
+    INACTIVE: "inactive",
+    WORK: "work",
+    REST: "rest",
+  };
+  const [countdownMode, setCountdownMode] = useState(MODES.INACTIVE);
 
   //カウントダウンタイマーのIDを保持する
   const timerRef = useRef(0);

--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -73,9 +73,6 @@ const Countdown = () => {
     const soundToPlay = isWorkMode ? sound.finishWork : sound.finishRest;
     soundToPlay.play();
 
-    //作業フラグを切り替える
-    setIsWorkMode((prev) => !prev);
-
     startTimer();
 
   },[remainingTimeMs]);

--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -66,11 +66,11 @@ const Countdown = () => {
     clearInterval(timerRef.current);
 
     // 次のタイマー時間を設定
-    const nextTime = isWorkMode ? restTime : workTime;
+    const nextTime = countdownMode === MODES.WORK ? restTime : workTime;
     setRemainingTimeMs(nextTime);
 
     // 作業か休憩の終了に応じてチャイムを鳴らす
-    const soundToPlay = isWorkMode ? sound.finishWork : sound.finishRest;
+    const soundToPlay = countdownMode === MODES.WORK ? sound.finishWork : sound.finishRest;
     soundToPlay.play();
 
     startTimer();

--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -54,6 +54,7 @@ const Countdown = () => {
     clearInterval(timerRef.current)
     setRemainingTimeMs(workTime);
     setIsCountingDown(false);
+    setCountdownMode(MODES.INACTIVE);
   };
 
   //カウントダウン終了時の処理

--- a/src/Countdown.jsx
+++ b/src/Countdown.jsx
@@ -80,7 +80,13 @@ const Countdown = () => {
   return (
     <div className="Countdown">
       <p>{ formattedMins } : { formattedSecs  }</p>
-      <p>{ isWorkMode ? '作業中' : '休憩中' }</p>
+      <p>
+        {countdownMode === MODES.WORK
+          ? "作業中"
+          : countdownMode === MODES.REST
+          ? "休憩中"
+          : null}
+      </p>
       <button onClick={startTimer} disabled={ isCountingDown }>スタート</button>
       <button onClick={stopTimer}>ストップ</button>
       <button onClick={resetTimer}>リセット</button>


### PR DESCRIPTION
### 概要
カウントダウン開始前（初期状態）では、「作業中」の文字を表示しないようにする

---
### 背景・目的
現状、カウントダウン開始前（初期状態）では、「作業中」の文字が表示されており、作業時間のカウントダウンが既に実行中なのか混乱するため。

---
### タスク
- [x] カウントダウン開始前の状態を管理するため、３つの状態（inactive, work, rest）を定数で定義する
```js
  const MODES = {
    INACTIVE: "inactive",
    WORK: "work",
    REST: "rest",
  };
```
- [x] `countdownMode`stateを定義する（デフォルトは、`"inactive"`とする）
- [x] `countdownMode`が`work`の時は"作業中", `rest`の時は"休憩中", `inactive`の時は何も表示しないようにする
- [x] カウントダウン開始時には、`countdownMode`を`work`にする。
- [x] カウントダウンリセット時には、`countdownMode`を`inactive`にする。
- [x] 作業時間のカウントダウンが終了したら、`countdownMode`を`rest`にする。
- [x] 休憩時間のカウントダウンが終了したら、`countdownMode`を`work`にする。

---
### UIスクショ
[![Image from Gyazo](https://i.gyazo.com/6bd334d5b6aa043660e2a08a89bafa7a.gif)](https://gyazo.com/6bd334d5b6aa043660e2a08a89bafa7a)
**動作確認のため、作業時間、及び休憩時間を短縮しています** 

---
### 補足
- 定数は、カウントダウン状態が３つあることを明示するために定義しています