### PR TITLE
作業時間・休憩時間をDBに保存する

### DIFF
--- a/backend/app/controllers/v1/timer_records_controller.rb
+++ b/backend/app/controllers/v1/timer_records_controller.rb
@@ -1,21 +1,16 @@
 class V1::TimerRecordsController < ApplicationController
   before_action :authenticate_v1_user!
+  before_action :find_today_timer_record, only: [:create_or_update]
 
   def create_or_update
-    # 今日の日付を取得
-    today = Time.zone.today
-
-    today_timer_record = current_v1_user.timer_records.find_by(recorded_date: today)
-
-    if today_timer_record
-      # 日付が一致するレコードがあれば更新する
-      if today_timer_record.update(timer_record_params)
-        render json: { message: '計測時間レコードが更新されました', data: today_timer_record }
+    # 日付が一致するレコードがあれば更新する。なければ、新しくレコードをつくる
+    if @today_timer_record
+      if @today_timer_record.update(merged_time_elapsed_ms(@today_timer_record))
+        render json: { message: '計測時間レコードが更新されました', data: @today_timer_record }
       else
-        render json: { message: '計測時間レコードの更新に失敗しました', errors: today_timer_record.errors.full_messages }
+        render json: { message: '計測時間レコードの更新に失敗しました', errors: @today_timer_record.errors.full_messages }
       end
     else
-      # 日付が一致するレコードがなければ新しくつくる
       new_timer_record = current_v1_user.timer_records.new(timer_record_params.merge(recorded_date: today))
       if new_timer_record.save
         render json: { message: '新しい計測時間レコードが保存されました' }
@@ -29,5 +24,16 @@ class V1::TimerRecordsController < ApplicationController
 
   def timer_record_params
     params.permit(:work_time_elapsed_ms, :rest_time_elapsed_ms)
+  end
+
+  def merged_time_elapsed_ms(timer_record)
+    {
+      work_time_elapsed_ms: timer_record.work_time_elapsed_ms.to_i + timer_record_params[:work_time_elapsed_ms].to_i,
+      rest_time_elapsed_ms: timer_record.rest_time_elapsed_ms.to_i + timer_record_params[:rest_time_elapsed_ms].to_i
+    }
+  end
+
+  def find_today_timer_record
+    @today_timer_record = current_v1_user.timer_records.find_by(recorded_date: Time.zone.today)
   end
 end

--- a/backend/app/controllers/v1/timer_records_controller.rb
+++ b/backend/app/controllers/v1/timer_records_controller.rb
@@ -28,6 +28,6 @@ class V1::TimerRecordsController < ApplicationController
   private
 
   def timer_record_params
-    params.permit(:study_time_ms, :rest_time_ms)
+    params.permit(:work_time_elapsed_ms, :rest_time_elapsed_ms)
   end
 end

--- a/backend/app/controllers/v1/timer_records_controller.rb
+++ b/backend/app/controllers/v1/timer_records_controller.rb
@@ -1,0 +1,33 @@
+class V1::TimerRecordsController < ApplicationController
+  before_action :authenticate_v1_user!
+
+  def create_or_update
+    # 今日の日付を取得
+    today = Time.zone.today
+
+    today_timer_record = current_v1_user.timer_records.find_by(recorded_date: today)
+
+    if today_timer_record
+      # 日付が一致するレコードがあれば更新する
+      if today_timer_record.update(timer_record_params)
+        render json: { message: '計測時間レコードが更新されました', data: today_timer_record }
+      else
+        render json: { message: '計測時間レコードの更新に失敗しました', errors: today_timer_record.errors.full_messages }
+      end
+    else
+      # 日付が一致するレコードがなければ新しくつくる
+      new_timer_record = current_v1_user.timer_records.new(timer_record_params.merge(recorded_date: today))
+      if new_timer_record.save
+        render json: { message: '新しい計測時間レコードが保存されました' }
+      else
+        render json: { message: '新しい計測時間レコードの保存に失敗しました', errors: new_timer_record.errors.full_messages }
+      end
+    end
+  end
+
+  private
+
+  def timer_record_params
+    params.permit(:study_time_ms, :rest_time_ms)
+  end
+end

--- a/backend/app/models/timer_record.rb
+++ b/backend/app/models/timer_record.rb
@@ -1,0 +1,3 @@
+class TimerRecord < ApplicationRecord
+  belongs_to :user
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -6,4 +6,7 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
   include DeviseTokenAuth::Concerns::User
+
+  has_many :timer_records, dependent: :destroy
+
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -9,5 +9,7 @@ Rails.application.routes.draw do
     namespace :auth do
       resources :sessions, only: %i[index]
     end
+
+    post 'timer_records', to: 'timer_records#create_or_update'
   end
 end

--- a/backend/db/migrate/20250111030636_create_timer_records.rb
+++ b/backend/db/migrate/20250111030636_create_timer_records.rb
@@ -1,0 +1,12 @@
+class CreateTimerRecords < ActiveRecord::Migration[7.1]
+  def change
+    create_table :timer_records do |t|
+      t.integer :study_time_ms
+      t.integer :rest_time_ms
+      t.date :recorded_date
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20250111060108_rename_time_columns_in_timer_records.rb
+++ b/backend/db/migrate/20250111060108_rename_time_columns_in_timer_records.rb
@@ -1,0 +1,6 @@
+class RenameTimeColumnsInTimerRecords < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :timer_records, :study_time_ms, :work_time_elapsed_ms
+    rename_column :timer_records, :rest_time_ms, :rest_time_elapsed_ms
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_08_073202) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_11_030636) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "timer_records", force: :cascade do |t|
+    t.integer "study_time_ms"
+    t.integer "rest_time_ms"
+    t.date "recorded_date"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_timer_records_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false
@@ -39,4 +49,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_08_073202) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "timer_records", "users"
 end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_11_030636) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_11_060108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "timer_records", force: :cascade do |t|
-    t.integer "study_time_ms"
-    t.integer "rest_time_ms"
+    t.integer "work_time_elapsed_ms"
+    t.integer "rest_time_elapsed_ms"
     t.date "recorded_date"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false

--- a/frontend/src/api/SaveTimerRecord.js
+++ b/frontend/src/api/SaveTimerRecord.js
@@ -1,0 +1,30 @@
+import client from "./apiClient";
+import Cookies from "js-cookie";
+
+const saveTimerRecord = async (workTimeElapsedMs, restTimeElapsedMs) => {
+  const params = {
+    workTimeElapsedMs,
+    restTimeElapsedMs,
+  };
+  try {
+    const res = await client.post(
+      "v1/timer_records",
+      params,
+      {
+        headers: {
+          "access-token": Cookies.get("_access_token"),
+          client: Cookies.get("_client"),
+          uid: Cookies.get("_uid"),
+        },
+      }
+    );
+    if (res.status === 200) {
+      return true;
+    }
+  } catch (e) {
+    console.log(e);
+  } finally {
+  };
+};
+
+export default saveTimerRecord;

--- a/frontend/src/components/Countdown.jsx
+++ b/frontend/src/components/Countdown.jsx
@@ -10,6 +10,10 @@ const Countdown = () => {
   const remainingTimeMins = Math.floor(remainingTimeMs / 1000 / 60);
   const remainingTimeSecs = Math.floor(remainingTimeMs / 1000 % 60);
 
+  //経過時間を保持する変数
+  const [workTimeElapsedMs, setWorkTimeElapsedMs] = useState(0);
+  const [restTimeElapsedMs, setRestTimeElapsedMs] = useState(0);
+
   //２桁で時間表示する
   const formattedMins = remainingTimeMins < 10 ? "0" + remainingTimeMins : remainingTimeMins;
   const formattedSecs = remainingTimeSecs < 10 ? "0" + remainingTimeSecs : remainingTimeSecs;
@@ -44,6 +48,7 @@ const Countdown = () => {
     setRemainingTimeMs(countdownMode === MODES.WORK ? workTime : restTime)
     const timerId = setInterval(() => {
       setRemainingTimeMs((prev) => prev - 1000);
+      countdownMode === MODES.WORK ? setWorkTimeElapsedMs((prev) => prev + 1000) : setRestTimeElapsedMs((prev) => prev + 1000);
     }, 1000);
 
     timerRef.current = timerId;

--- a/frontend/src/components/Countdown.jsx
+++ b/frontend/src/components/Countdown.jsx
@@ -86,6 +86,10 @@ const Countdown = () => {
   const stopTimer = () => {
     clearInterval(timerRef.current);
     setIsCountingDown(false);
+
+    saveTimerRecord(workTimeElapsedMs, restTimeElapsedMs);
+    setWorkTimeElapsedMs(0);
+    setRestTimeElapsedMs(0);
   };
 
   //----------リセット----------
@@ -94,6 +98,10 @@ const Countdown = () => {
     setRemainingTimeMs(workTime);
     setIsCountingDown(false);
     setCountdownMode(MODES.INACTIVE);
+
+    saveTimerRecord(workTimeElapsedMs, restTimeElapsedMs);
+    setWorkTimeElapsedMs(0);
+    setRestTimeElapsedMs(0);
   };
 
   //----------カウントダウン終了時の処理----------

--- a/frontend/src/components/Countdown.jsx
+++ b/frontend/src/components/Countdown.jsx
@@ -67,6 +67,20 @@ const Countdown = () => {
     setIsCountingDown(false);
     setCountdownMode(MODES.INACTIVE);
   };
+  //----------再開----------
+  const restartTimer = () => {
+    if (countdownMode === MODES.INACTIVE) return;
+
+    //時間は初期化しない（ストップした時点から計測を再開するため）
+
+    const timerId = setInterval(() => {
+      setRemainingTimeMs((prev) => prev - 1000);
+      countdownMode === MODES.WORK ? setWorkTimeElapsedMs((prev) => prev + 1000) : setRestTimeElapsedMs((prev) => prev + 1000);
+    }, 1000);
+
+    timerRef.current = timerId;
+    setIsCountingDown(true);
+  }
 
   //カウントダウン終了時の処理
   useEffect(() => {

--- a/frontend/src/components/Countdown.jsx
+++ b/frontend/src/components/Countdown.jsx
@@ -84,6 +84,15 @@ const Countdown = () => {
 
   },[remainingTimeMs]);
 
+  //1分ごとにAPIに経過時間を送信し、経過時間の状態をリセット
+  useEffect(()=>{
+    if (remainingTimeMs % (60 * 1000) === 0){
+      saveTimerRecord(workTimeElapsedMs, restTimeElapsedMs);
+      setWorkTimeElapsedMs(0);
+      setRestTimeElapsedMs(0);
+    };
+  },[remainingTimeMs])
+
   useEffect(()=>{
     startTimer();
   },[countdownMode]);

--- a/frontend/src/components/Countdown.jsx
+++ b/frontend/src/components/Countdown.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import saveTimerRecord from '../api/SaveTimerRecord';
 
 const Countdown = () => {
   //作業時間25分、休憩時間5分とする

--- a/frontend/src/components/Countdown.jsx
+++ b/frontend/src/components/Countdown.jsx
@@ -1,6 +1,4 @@
-import { useState } from 'react';
-import { useEffect } from 'react';
-import { useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 const Countdown = () => {
   //作業時間25分、休憩時間5分とする

--- a/frontend/src/components/Countdown.jsx
+++ b/frontend/src/components/Countdown.jsx
@@ -33,14 +33,21 @@ const Countdown = () => {
     finishRest: new Audio("/finishRestChime.wav")
   };
 
+  const changeMode = () => {
+    setCountdownMode(countdownMode === MODES.WORK ? MODES.REST : MODES.WORK)
+  };
+
   //タイマー機能(開始、停止、リセット)
   const startTimer = () => {
+    if (countdownMode === MODES.INACTIVE) return;
+
+    setRemainingTimeMs(countdownMode === MODES.WORK ? workTime : restTime)
     const timerId = setInterval(() => {
-      setRemainingTimeMs((prev) => prev - 1000)
+      setRemainingTimeMs((prev) => prev - 1000);
     }, 1000);
+
     timerRef.current = timerId;
     setIsCountingDown(true);
-    setCountdownMode((prev) => prev !== MODES.WORK ? MODES.WORK : MODES.REST);
   };
 
   const stopTimer = () => {
@@ -63,17 +70,18 @@ const Countdown = () => {
     //稼働中のタイマーを停止する
     clearInterval(timerRef.current);
 
-    // 次のタイマー時間を設定
-    const nextTime = countdownMode === MODES.WORK ? restTime : workTime;
-    setRemainingTimeMs(nextTime);
+    // 次のカウントダウンモードを設定
+    changeMode();
 
-    // 作業か休憩の終了に応じてチャイムを鳴らす
+    // 作業、または休憩の終了に応じてチャイムを鳴らす
     const soundToPlay = countdownMode === MODES.WORK ? sound.finishWork : sound.finishRest;
     soundToPlay.play();
 
-    startTimer();
-
   },[remainingTimeMs]);
+
+  useEffect(()=>{
+    startTimer();
+  },[countdownMode]);
 
   return (
     <div className="Countdown">
@@ -85,7 +93,7 @@ const Countdown = () => {
           ? "休憩中"
           : null}
       </p>
-      <button onClick={startTimer} disabled={ isCountingDown }>スタート</button>
+      <button onClick={changeMode} disabled={ isCountingDown }>スタート</button>
       <button onClick={stopTimer}>ストップ</button>
       <button onClick={resetTimer}>リセット</button>
     </div>

--- a/frontend/src/components/Countdown.jsx
+++ b/frontend/src/components/Countdown.jsx
@@ -122,7 +122,20 @@ const Countdown = () => {
           ? "休憩中"
           : null}
       </p>
-      <button onClick={changeMode} disabled={ isCountingDown }>スタート</button>
+
+      {/* countdownModeがinactiveであれば、changeModeを実行し、startTimer関数を発火させる。
+          workまたはrestであればすでにスタート済みなので、restart関数を発火させる（ただし、isCountingDownがtrueの時は非表示にする） */}
+      {
+        countdownMode === MODES.INACTIVE ? (
+          <button onClick={changeMode}>
+            スタート
+          </button>
+        ) : (
+          <button onClick={restartTimer} hidden={ isCountingDown }>
+            リスタート
+          </button>
+        )
+      }
       <button onClick={stopTimer}>ストップ</button>
       <button onClick={resetTimer}>リセット</button>
     </div>

--- a/frontend/src/components/Countdown.jsx
+++ b/frontend/src/components/Countdown.jsx
@@ -16,6 +16,11 @@ const Countdown = () => {
   const [workTimeElapsedMs, setWorkTimeElapsedMs] = useState(0);
   const [restTimeElapsedMs, setRestTimeElapsedMs] = useState(0);
 
+  //経過時間をリセットする
+  const resetTimeElapsedMs = () => {
+    setWorkTimeElapsedMs(0);
+    setRestTimeElapsedMs(0);
+  };
 
   //----------計測モード----------
   const MODES = {
@@ -88,8 +93,7 @@ const Countdown = () => {
     setIsCountingDown(false);
 
     saveTimerRecord(workTimeElapsedMs, restTimeElapsedMs);
-    setWorkTimeElapsedMs(0);
-    setRestTimeElapsedMs(0);
+    resetTimeElapsedMs();
   };
 
   //----------リセット----------
@@ -100,8 +104,7 @@ const Countdown = () => {
     setCountdownMode(MODES.INACTIVE);
 
     saveTimerRecord(workTimeElapsedMs, restTimeElapsedMs);
-    setWorkTimeElapsedMs(0);
-    setRestTimeElapsedMs(0);
+    resetTimeElapsedMs();
   };
 
   //----------カウントダウン終了時の処理----------
@@ -126,8 +129,7 @@ const Countdown = () => {
   useEffect(()=>{
     if (remainingTimeMs % (60 * 1000) === 0){
       saveTimerRecord(workTimeElapsedMs, restTimeElapsedMs);
-      setWorkTimeElapsedMs(0);
-      setRestTimeElapsedMs(0);
+      resetTimeElapsedMs();
     };
   },[remainingTimeMs])
 


### PR DESCRIPTION
### 概要
作業時間・休憩時間をDBに保存する
close # 32

---
### 背景・目的
各ユーザーの作業時間・休憩時間を日付ごとに表示できるようにするため。

---
### やったこと
#### フロント
##### 方針
1. APIに経過時間を送信するタイミングは、①1分ごと　②ストップボタン押下時　③リセットボタン押下時の３つ
2. DBの経過時間に加算するので、APIに経過時間送信後は、経過時間を0に戻す

- [x] `countdown`コンポーネント
  - [x] 作業・休憩の経過時間をstateで保持する（`workTimeElapsedMs`, `restTimeElapsedMs`）
  - [x] 作業時間・休憩時間を1秒ごとにstateに入れる
  - [x] １分ごとに、`SaveTimerRecord`を実行し、`workTimeElapsedMs`, `restTimeElapsedMs`を`0`にリセットする
  - [x] ストップボタン、またはリセットボタンを押されたときも、`SaveTimerRecord`を実行
  - [x] `countdownMode`が変化するごとに`startTimer`を発火させる
  - [x] カウントダウンを再開する`restartTimer`関数を定義する（カウントダウンのストップ時の`countdownMode`を継続利用する）
  - [x] `countdownMode`が`inactive`の場合は、スタートボタンを表示し、`countdownMode`を変更させる（これにより、startTimer`が発火する
  - [x] `countdownMode`が`inactive`以外の場合（カウントダウン中）は、リスタートボタンを表示し、押下されると`restartTimer`を発火させる。ただし、カウントダウン中は、`disabled`とし、ストップ中に押下できるようにする。 
- [x] `SaveTimerRecord`関数の定義
  - [x] `workTimeElapsedMs`, `restTimeElapsedMs`を受け取り、`params`にセットする
  - [x] `v1/timer_records`にPOSTでリクエストを送る（その際、`params`をボディーに、`access_token``uid``clinet`をヘッダーに入れる）


#### バック
##### 方針
1. DBには、日付ごとに計測時間を保存する
2. 既にその日（計測された日）の日付の`timer_record`レコードが作成されている場合は、そのレコードを更新する
3. まだその日（計測された日）の日付の`timer_record`レコードが作成されていない場合は、新しくレコードを作成する

- [x] `TimerRecord`モデルを作成する（Userモデルと１対多のアソシエーション）
- [x] `timer_records`テーブルを作成する（usersテーブルと１対多のアソシエーション）
  - カラムは以下のとおりとする
    - study_time_ms: integer
    - rest_time_ms: integer
    - recorded_date: date
- [x] ルーティングは、名前空間`v1`の中に入れる
-  コントローラー
  - [x] 認証情報を使い、`timer_record`をユーザーと紐づけて登録する
  - [x] 既にその日（計測された日）の日付の`timer_record`レコードが作成されている場合は、そのレコードを更新する
  - [x] まだその日（計測された日）の日付の`timer_record`レコードが作成されていない場合は、新しくレコードを作成する
  - [x] パラメーターで受け取った経過時間を、既に登録されている経過時間に加算する（更新の場合）

---
### 補足
- 0~59秒の間にページ更新が行われると、経過時間がDBに保存されないという課題があります。
- この課題を認識しつつ、まずは1分ごとにDBに保存する処理で実装しました。
- 毎秒、ブラウザのlocal storageに保存し、バッチ処理でDBに保存する方法もあるかと思いますので、別途検討していきます。