### PR TITLE
作業・休憩時間記録を表示するページを作成

### DIFF
--- a/backend/app/controllers/v1/timer_records_controller.rb
+++ b/backend/app/controllers/v1/timer_records_controller.rb
@@ -2,6 +2,11 @@ class V1::TimerRecordsController < ApplicationController
   before_action :authenticate_v1_user!
   before_action :find_today_timer_record, only: [:create_or_update]
 
+  def index
+    timer_records = current_v1_user.timer_records
+    render json: { user: current_v1_user, data: timer_records }
+  end
+
   def create_or_update
     # 日付が一致するレコードがあれば更新する。なければ、新しくレコードをつくる
     if @today_timer_record

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -11,5 +11,6 @@ Rails.application.routes.draw do
     end
 
     post 'timer_records', to: 'timer_records#create_or_update'
+    resources :timer_records, only: %i[index]
   end
 end

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,7 +6,7 @@ import SignOut from './components/SignOut';
 import SignUp from './components/SignUp';
 import Home from './components/Home';
 import TimerRecordsList from './components/TimerRecordsList';
-// import PrivateRoute from './components/PrivateRoute';
+import PrivateRoute from './routes/PrivateRoute';
 
 function App() {
   return (
@@ -17,7 +17,13 @@ function App() {
             <Route path="/" element={<Home />} />
             <Route path="/signin" element={<SignIn />} />
             <Route path="/signup" element={<SignUp />} />
-            <Route path="/timer_records" element={<TimerRecordsList />} />
+            <Route
+              path="/timer_records"
+              element={
+              <PrivateRoute>
+                <TimerRecordsList />
+              </PrivateRoute>
+            } />
           </Routes>
         </Router>
       </AuthProvider>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import SignIn from './components/SignIn';
 import SignOut from './components/SignOut';
 import SignUp from './components/SignUp';
 import Home from './components/Home';
+import TimerRecordsList from './components/TimerRecordsList';
 // import PrivateRoute from './components/PrivateRoute';
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
             <Route path="/" element={<Home />} />
             <Route path="/signin" element={<SignIn />} />
             <Route path="/signup" element={<SignUp />} />
+            <Route path="/timer_records" element={<TimerRecordsList />} />
           </Routes>
         </Router>
       </AuthProvider>

--- a/frontend/src/components/AuthProvider.jsx
+++ b/frontend/src/components/AuthProvider.jsx
@@ -121,7 +121,7 @@ const AuthProvider = ( {children} ) => {
       });
       if (res?.data.isLogin === true) {
         setIsSignedIn(true);
-        // setCurrentUser(res?.data.data);
+        setUser(res?.data.data);
         console.log(res?.data.data);
       } else {
         console.log(res?.data.data);

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -16,7 +16,10 @@ const Home = () => {
     <>
       <Countdown />
       { isSignedIn ? (
-        <SignOut/>
+        <>
+          <SignOut/>
+          <Link to="/timer_records">記録ページ</Link>
+        </>
       ) : (
         <>
           <Link to="/signin">サインイン</Link>

--- a/frontend/src/components/TimerRecordsList.jsx
+++ b/frontend/src/components/TimerRecordsList.jsx
@@ -55,28 +55,30 @@ const TimerRecordsList = () => {
   return (
     <div>
       {timerRecords ? (
-        <table>
-          <thead>
-            <tr>
-              <th>日付</th>
-              <th>作業時間（分）</th>
-              <th>休憩時間（分）</th>
-            </tr>
-          </thead>
-          <tbody>
-            {timerRecords.map((timerRecord, index) => (
-              <tr key={index}>
-                <td>{formatDateToJapanese(timerRecord.recordedDate)}</td>
-                <td>{Math.floor(timerRecord.workTimeElapsedMs / 1000 / 60)}分</td>
-                <td>{Math.floor(timerRecord.restTimeElapsedMs / 1000 / 60)}分</td>
+        <>
+          <table>
+            <thead>
+              <tr>
+                <th>日付</th>
+                <th>作業時間（分）</th>
+                <th>休憩時間（分）</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {timerRecords.map((timerRecord, index) => (
+                <tr key={index}>
+                  <td>{formatDateToJapanese(timerRecord.recordedDate)}</td>
+                  <td>{Math.floor(timerRecord.workTimeElapsedMs / 1000 / 60)}分</td>
+                  <td>{Math.floor(timerRecord.restTimeElapsedMs / 1000 / 60)}分</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <button onClick={() => navigate("/")}>ホーム</button>
+        </>
       ) : (
         ""
       )}
-      <button onClick={() => navigate("/")}>ホーム</button>
     </div>
   );
 }

--- a/frontend/src/components/TimerRecordsList.jsx
+++ b/frontend/src/components/TimerRecordsList.jsx
@@ -1,6 +1,7 @@
 import client from "../api/apiClient";
 import { useEffect, useState } from "react";
 import Cookies from "js-cookie";
+import { useNavigate } from "react-router-dom";
 
 const TimerRecordsList = () => {
 
@@ -49,6 +50,8 @@ const TimerRecordsList = () => {
     return `${year}年${month}月${day}日`; // フォーマットされた日付
   };
 
+  const navigate = useNavigate();
+
   return (
     <div>
       {timerRecords ? (
@@ -73,6 +76,7 @@ const TimerRecordsList = () => {
       ) : (
         "Loading..."
       )}
+      <button onClick={() => navigate("/")}>ホーム</button>
     </div>
   );
 }

--- a/frontend/src/components/TimerRecordsList.jsx
+++ b/frontend/src/components/TimerRecordsList.jsx
@@ -1,7 +1,7 @@
 import client from "../api/apiClient";
 import { useEffect, useState } from "react";
 import Cookies from "js-cookie";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 const TimerRecordsList = () => {
 
@@ -50,8 +50,6 @@ const TimerRecordsList = () => {
     return `${year}年${month}月${day}日`; // フォーマットされた日付
   };
 
-  const navigate = useNavigate();
-
   return (
     <div>
       {timerRecords ? (
@@ -74,7 +72,7 @@ const TimerRecordsList = () => {
               ))}
             </tbody>
           </table>
-          <button onClick={() => navigate("/")}>ホーム</button>
+          <Link to="/">ホーム</Link>
         </>
       ) : (
         ""

--- a/frontend/src/components/TimerRecordsList.jsx
+++ b/frontend/src/components/TimerRecordsList.jsx
@@ -74,7 +74,7 @@ const TimerRecordsList = () => {
           </tbody>
         </table>
       ) : (
-        "Loading..."
+        ""
       )}
       <button onClick={() => navigate("/")}>ホーム</button>
     </div>

--- a/frontend/src/components/TimerRecordsList.jsx
+++ b/frontend/src/components/TimerRecordsList.jsx
@@ -1,0 +1,80 @@
+import client from "../api/apiClient";
+import { useEffect, useState } from "react";
+import Cookies from "js-cookie";
+
+const TimerRecordsList = () => {
+
+  const [timerRecords, setTimerRecords] = useState(null);
+
+  useEffect(() => {
+    fetchTimerRecords()
+  },[]);
+
+  const fetchTimerRecords = async () => {
+    if (
+      !Cookies.get("_access_token") ||
+      !Cookies.get("_client") ||
+      !Cookies.get("_uid")
+    )
+      return;
+
+    try {
+      const res = await client.get("v1/timer_records", {
+        headers: {
+          "access-token": Cookies.get("_access_token"),
+          client: Cookies.get("_client"),
+          uid: Cookies.get("_uid"),
+        },
+      });
+      if (res.status === 200) {
+        console.log(res?.data.data);
+        setTimerRecords(res?.data.data)
+      } else {
+        console.log(res?.data.data);
+        console.log("no current user");
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  const formatDateToJapanese = (dateString) => {
+    // 文字列をDateオブジェクトに変換
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    // 0から始まるので+1をする
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+
+    return `${year}年${month}月${day}日`; // フォーマットされた日付
+  };
+
+  return (
+    <div>
+      {timerRecords ? (
+        <table>
+          <thead>
+            <tr>
+              <th>日付</th>
+              <th>作業時間（分）</th>
+              <th>休憩時間（分）</th>
+            </tr>
+          </thead>
+          <tbody>
+            {timerRecords.map((timerRecord, index) => (
+              <tr key={index}>
+                <td>{formatDateToJapanese(timerRecord.recordedDate)}</td>
+                <td>{Math.floor(timerRecord.workTimeElapsedMs / 1000 / 60)}分</td>
+                <td>{Math.floor(timerRecord.restTimeElapsedMs / 1000 / 60)}分</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        "Loading..."
+      )}
+    </div>
+  );
+}
+
+export default TimerRecordsList;


### PR DESCRIPTION
### 概要
作業・休憩時間記録を表示するページを作成

close #34 

---
### 背景・目的
過去の作業・休憩時間記録をユーザーが確認できるようにするため

---
### やったこと
#### フロントエンド
- [x] 作業時間・休憩時間記録を表示するコンポーネント（`TimerRecordsList`）を作成する
  - [x] `v1/timer_records`パスにGetリクエストを送る（その際、認証情報をヘッダーに含める）
  - [x] APIからの作業時間・休憩時間記録を、日付ごとにテーブル形式で表示させる
  - [x] `Home`コンポーネントへのリンクを表示する
- [x] `Home`コンポーネントで、記録ページへのリンクを設置する（ログインユーザーに対してのみ）
- [x] `PrivateRoute`コンポーネントを作成し、``TimerRecordsList`コンポーネントをラップする
  - [x] 未ログインユーザーは、サインインページに遷移させる

#### バックエンド
- [x] `v1/timer_records`パスに、Getリクエストを受けると、ユーザーに紐づくtimer_recordsレコードをJSON形式で返す処理を実装する

---
### スクショ
[![Image from Gyazo](https://i.gyazo.com/0ed74fadcb2d752a556b1aceb4024b49.png)](https://gyazo.com/0ed74fadcb2d752a556b1aceb4024b49)

---
### 対応しないこと
- スタイルは実装しない（時間に余裕があれば行う）

---
### 補足
なし