### PR TITLE
Feat/#38 keep session

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -39,6 +39,9 @@ gem "rack-cors"
 gem 'devise'
 gem 'devise_token_auth'
 
+# email
+gem 'letter_opener_web'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
       mutex_m
       securerandom (>= 0.3)
       tzinfo (~> 2.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
@@ -85,6 +87,8 @@ GEM
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     builder (3.3.0)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.5.0)
@@ -118,6 +122,16 @@ GEM
     irb (1.14.3)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    launchy (3.0.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     logger (1.6.4)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -169,6 +183,7 @@ GEM
     psych (5.2.2)
       date
       stringio
+    public_suffix (6.0.1)
     puma (6.5.0)
       nio4r (~> 2.0)
     racc (1.8.1)
@@ -219,6 +234,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rexml (3.4.0)
     securerandom (0.4.1)
     stringio (3.1.2)
     thor (1.3.2)
@@ -250,6 +266,7 @@ DEPENDENCIES
   devise_token_auth
   dotenv-rails
   error_highlight (>= 0.4.0)
+  letter_opener_web
   pg (~> 1.1)
   pry-rails
   puma (>= 5.0)

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -33,8 +33,7 @@ module Backend
     config.middleware.use ActionDispatch::Flash
     config.middleware.insert_before 0, Rack::Cors do
       allow do
-        # ローカルではReactのポートを3001とする。Reactのリクエストを許可するためにlocalhost:3001を設定
-        origins 'localhost:3001'
+        origins ENV.fetch("CORS_ALLOWED_ORIGINS")
         resource '*',
                  :headers => :any,
                  # リクエストヘッダーの'access-token'、'uid'、'client'を用いてログイン状態を維持する。

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -34,22 +34,24 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_options = { from: ENV['EMAIL_ADDRESS'] }
+  config.action_mailer.default_options = { from: ENV.fetch("EMAIL_ADDRESS") }
+  config.action_mailer.default_url_options = { host: ENV.fetch("APP_SERVER_HOST") }
 
-  config.action_mailer.default_url_options = { host: 'localhost:3000' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address: 'smtp.gmail.com',
     port: 587,
     domain: 'gmail.com',
-    user_name: ENV['EMAIL_ADDRESS'],
-    password: ENV['EMAIL_PASSWORD'],
-    authentication: 'plain',
-    enable_starttls_auto: true
+    user_name: ENV.fetch("EMAIL_ADDRESS"),
+    password: ENV.fetch("EMAIL_PASSWORD"),
+    authentication: :plain,
+    enable_starttls_auto: true,
+    open_timeout: 10, # ← 追加
+    read_timeout: 10  # ← 追加
   }
 
   # Print deprecation notices to the Rails logger.

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -64,7 +64,25 @@ Rails.application.configure do
   # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "backend_production"
 
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
+
+  config.action_mailer.default_options = { from: ENV.fetch("EMAIL_ADDRESS") }
+  config.action_mailer.default_url_options = { host: ENV.fetch("APP_SERVER_HOST") }
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: 'smtp.gmail.com',
+    port: 587,
+    domain: 'gmail.com',
+    user_name: ENV.fetch("EMAIL_ADDRESS"),
+    password: ENV.fetch("EMAIL_PASSWORD"),
+    authentication: :plain,
+    enable_starttls_auto: true,
+    open_timeout: 10, # ← 追加
+    read_timeout: 10  # ← 追加
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   namespace :v1 do
     # 認証機能
     mount_devise_token_auth_for 'User', at: 'auth', controllers: {

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,2 @@
 REACT_APP_API_BASE_URL=http://localhost:3000
+REACT_APP_FRONT_SIGN_IN_URL=http://localhost:3001/signin

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
-REACT_APP_API_BASE_URL=http://localhost:3000
+REACT_APP_BACK_BASE_URL=http://localhost:3000
 REACT_APP_FRONT_SIGN_IN_URL=http://localhost:3001/signin

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,7 +2,6 @@ import './App.css';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import AuthProvider from './components/AuthProvider';
 import SignIn from './components/SignIn';
-import SignOut from './components/SignOut';
 import SignUp from './components/SignUp';
 import Home from './components/Home';
 import TimerRecordsList from './components/TimerRecordsList';

--- a/frontend/src/api/apiClient.ts
+++ b/frontend/src/api/apiClient.ts
@@ -4,7 +4,7 @@ import axios, { AxiosInstance } from 'axios';
 // API通信を行うためのクライアント設定
 const client: AxiosInstance = applyCaseMiddleware(
     axios.create({
-        baseURL: process.env.REACT_APP_API_BASE_URL || 'http://localhost:3000',
+        baseURL: process.env.REACT_APP_BACK_BASE_URL,
     }),
 );
 

--- a/frontend/src/api/saveTimerRecord.ts
+++ b/frontend/src/api/saveTimerRecord.ts
@@ -27,6 +27,7 @@ const saveTimerRecord = async (workTimeElapsedMs: number, restTimeElapsedMs: num
     }
   } catch (e) {
     console.log(e);
+    alert("経過時間の記録に失敗しました。ログイン済みか確認ください")
   }
 };
 

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -43,10 +43,19 @@ const AuthContext = createContext<AuthContextType | null>(null);
 // 認証用のコンポーネント（ContextProvider）を作成
 // コンポーネントタグで囲んだ子コンポーネントを受け取れるようにする
 const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
+
+  //--------state--------
+  //認証後、APIから取得したユーザー情報を保持するstate
   const [user, setUser] = useState<AuthContextType["user"]>(null);
+
+  //API通信中の状態を保持するstate
   const [loading, setLoading] = useState<AuthContextType["loading"]>(false);
+
+  //サインイン状態を管理するstate
   const [isSignedIn, setIsSignedIn] = useState<AuthContextType["isSignedIn"]>(false);
 
+
+  //--------認証機能--------
   // サインアップ機能
   const signUp: AuthContextType["signUp"] = async ({email, password, passwordConfirmation, confirmSuccessUrl}) => {
     const params = {

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -17,7 +17,7 @@ interface SignUpArg {
   email: string;
   password: string;
   passwordConfirmation: string;
-  confirmSuccessUrl: string;
+  confirmSuccessUrl: string | undefined;
 }
 
 interface SignInArg {

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -73,6 +73,12 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
     };
   };
 
+  const clearAuthInCookies = () => {
+    Cookies.remove("_access_token");
+    Cookies.remove("_client");
+    Cookies.remove("_uid");
+  };
+
   //--------認証機能--------
   // サインアップ機能
   const signUp: AuthContextType["signUp"] = async ({email, password, passwordConfirmation, confirmSuccessUrl}) => {
@@ -141,6 +147,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
       if (res.status === 200) {
         setIsSignedIn(false);
         setUser(null);
+        clearAuthInCookies();
         alert("サインアウトしました");
         console.log("サインアウトに成功しました")
         return true;

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -101,7 +101,6 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
       const res = await client.post("v1/auth", params);
       if (res.status === 200) {
         setAuthToCookiesFromHeaders(res.headers)
-        setIsSignedIn(true);
         setUser(res.data.data);
         alert("登録したメールアドレスに、認証メールを送りました。メール内の確認リンクをクリックしてください");
         alert("サインアップ後は、サインインをしてください");
@@ -196,6 +195,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
     setHasFetched(true);
   };
 
+  // 初回レンダリング（ページ更新時を想定）で、ユーザー認証を実行する
   useEffect(() => {
     getCurrentUser();
     console.log("初回レンダリングで、AuthProviderからgetCurrentUserをuseEffectで実行")

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -87,8 +87,9 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
         setAuthToCookiesFromHeaders(res.headers)
         setIsSignedIn(true);
         setUser(res.data.data);
-        alert("登録したメールアドレスに、認証メールを送りました。メール内の確認リンクをクリックしてください")
-        alert("サインアップ後は、サインインをしてください")
+        alert("登録したメールアドレスに、認証メールを送りました。メール内の確認リンクをクリックしてください");
+        alert("サインアップ後は、サインインをしてください");
+        console.log("サインアップに成功しました（メール認証は未実施")
         return true;
       }
     } catch (e) {
@@ -113,6 +114,8 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
         setAuthToCookiesFromHeaders(res.headers)
         setIsSignedIn(true);
         setUser(res.data.data);
+        alert("サインインしました");
+        console.log("サインインに成功しました", res.data.data);
         return true;
       }
     } catch (e) {
@@ -128,9 +131,6 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
     setLoading(true);
 
     try {
-      console.log(Cookies.get("_access_token"));
-      console.log(Cookies.get("_client"),);
-      console.log(Cookies.get("_uid"));
       const res = await client.delete("v1/auth/sign_out", {
         headers: setAuthToHeadersFromCookies(),
       });
@@ -138,6 +138,8 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
       if (res.status === 200) {
         setIsSignedIn(false);
         setUser(null);
+        alert("サインアウトしました");
+        console.log("サインアウトに成功しました")
         return true;
       }
     } catch (e) {
@@ -166,10 +168,10 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
       if (res?.data.isLogin === true) {
         setIsSignedIn(true);
         setUser(res?.data.data);
-        console.log(res?.data.data);
+        console.log("ログインユーザー情報を取得しました",res?.data.data);
       } else {
         console.log(res?.data.data);
-        console.log("no current user");
+        console.log("ログインユーザー情報を取得できませんでした");
       }
     } catch (e) {
       console.log(e);

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -174,6 +174,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
       return;
 
     try {
+      //Cookieに認証情報があればログイン済みとすることもできるが、user情報はCookieに保存していないため、API通信を行う
       const res = await client.get("v1/auth/sessions", {
         headers: setAuthToHeadersFromCookies(),
       });
@@ -182,6 +183,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
         setUser(res?.data.data);
         console.log("ログインユーザー情報を取得しました",res?.data.data);
       } else {
+        //未ログインユーザーに対してはUIの出し分けやリダイレクトをするため、alertは表示しない
         setIsSignedIn(false);
         console.log(res?.data.data);
         console.log("ログインユーザー情報を取得できませんでした");

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -5,7 +5,6 @@ import { AxiosResponseHeaders, RawAxiosResponseHeaders } from 'axios';
 
 interface AuthContextType {
   user: User | null;
-  loading: boolean;
   isSignedIn: boolean;
   hasFetched: boolean;
   signUp: (args: SignUpArg) => Promise<boolean | void>;
@@ -56,9 +55,6 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
   //認証後、APIから取得したユーザー情報を保持するstate
   const [user, setUser] = useState<AuthContextType["user"]>(null);
 
-  //API通信中の状態を保持するstate
-  const [loading, setLoading] = useState<AuthContextType["loading"]>(true);
-
   //サインイン状態を管理するstate
   const [isSignedIn, setIsSignedIn] = useState<AuthContextType["isSignedIn"]>(false);
 
@@ -95,7 +91,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
       passwordConfirmation,
       confirmSuccessUrl,
     };
-    setLoading(true);
+    setHasFetched(false);
 
     try {
       const res = await client.post("v1/auth", params);
@@ -111,7 +107,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
       alert("サインアップに失敗しました")
       console.log(e);
     } finally {
-      setLoading(false);
+      setHasFetched(true);
     }
   };
 
@@ -121,7 +117,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
       email,
       password,
     };
-    setLoading(true);
+    setHasFetched(false);
 
     try {
       const res = await client.post("v1/auth/sign_in", params);
@@ -137,13 +133,13 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
       alert("サインインに失敗しました")
       console.log(e);
     } finally {
-      setLoading(false);
+      setHasFetched(true);
     }
   };
 
   // サインアウト機能
   const signOut: AuthContextType["signOut"] = async () => {
-    setLoading(true);
+    setHasFetched(false);
 
     try {
       const res = await client.delete("v1/auth/sign_out", {
@@ -162,13 +158,13 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
       alert("サインアウトに失敗しました")
       console.log(e);
     } finally {
-      setLoading(false);
+      setHasFetched(true);
     }
   };
 
   // ログインユーザーの取得
   const getCurrentUser: AuthContextType["getCurrentUser"] = async () => {
-    setLoading(true);
+    setHasFetched(false);
 
     if (
       !Cookies.get("_access_token") ||
@@ -202,7 +198,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
   },[]);
 
   return (
-    <AuthContext.Provider value={{ user, loading, isSignedIn, hasFetched, signIn, signOut, signUp, getCurrentUser }}>
+    <AuthContext.Provider value={{ user, isSignedIn, hasFetched, signIn, signOut, signUp, getCurrentUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, ReactNode } from 'react';
+import React, { createContext, useState, useContext, ReactNode, useEffect } from 'react';
 import Cookies from "js-cookie";
 import client from "../api/apiClient";
 
@@ -6,6 +6,7 @@ interface AuthContextType {
   user: User | null;
   loading: boolean;
   isSignedIn: boolean;
+  hasFetched: boolean;
   signUp: (args: SignUpArg) => Promise<boolean | void>;
   signIn: (args: SignInArg) => Promise<boolean | void>;
   signOut: () => Promise<boolean | void>;
@@ -49,11 +50,13 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
   const [user, setUser] = useState<AuthContextType["user"]>(null);
 
   //API通信中の状態を保持するstate
-  const [loading, setLoading] = useState<AuthContextType["loading"]>(false);
+  const [loading, setLoading] = useState<AuthContextType["loading"]>(true);
 
   //サインイン状態を管理するstate
   const [isSignedIn, setIsSignedIn] = useState<AuthContextType["isSignedIn"]>(false);
 
+  //APIとの通信完了を管理するstate
+  const [hasFetched, setHasFetched] = useState<AuthContextType["hasFetched"]>(false);
 
   //--------クッキー処理--------
   const setAuthToCookiesFromHeaders = (headers: any) => {
@@ -176,11 +179,16 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
     } catch (e) {
       console.log(e);
     }
-    setLoading(false);
+    setHasFetched(true);
   };
 
+  useEffect(() => {
+    getCurrentUser();
+    console.log("初回レンダリングで、AuthProviderからgetCurrentUserをuseEffectで実行")
+  },[]);
+
   return (
-    <AuthContext.Provider value={{ user, loading, isSignedIn, signIn, signOut, signUp, getCurrentUser }}>
+    <AuthContext.Provider value={{ user, loading, isSignedIn, hasFetched, signIn, signOut, signUp, getCurrentUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -55,6 +55,21 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
   const [isSignedIn, setIsSignedIn] = useState<AuthContextType["isSignedIn"]>(false);
 
 
+  //--------クッキー処理--------
+  const setAuthToCookiesFromHeaders = (headers: any) => {
+    Cookies.set("_access_token", headers["accessToken"]);
+    Cookies.set("_client", headers["client"]);
+    Cookies.set("_uid", headers["uid"]);
+  };
+
+  const setAuthToHeadersFromCookies = () => {
+    return {
+      "access-token": Cookies.get("_access_token"),
+      client: Cookies.get("_client"),
+      uid: Cookies.get("_uid"),
+    };
+  };
+
   //--------認証機能--------
   // サインアップ機能
   const signUp: AuthContextType["signUp"] = async ({email, password, passwordConfirmation, confirmSuccessUrl}) => {
@@ -69,10 +84,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
     try {
       const res = await client.post("v1/auth", params);
       if (res.status === 200) {
-        Cookies.set("_access_token", res.headers["accessToken"]);
-        Cookies.set("_client", res.headers["client"]);
-        Cookies.set("_uid", res.headers["uid"]);
-
+        setAuthToCookiesFromHeaders(res.headers)
         setIsSignedIn(true);
         setUser(res.data.data);
         alert("登録したメールアドレスに、認証メールを送りました。メール内の確認リンクをクリックしてください")
@@ -98,10 +110,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
     try {
       const res = await client.post("v1/auth/sign_in", params);
       if (res.status === 200) {
-        Cookies.set("_access_token", res.headers["accessToken"]);
-        Cookies.set("_client", res.headers["client"]);
-        Cookies.set("_uid", res.headers["uid"]);
-
+        setAuthToCookiesFromHeaders(res.headers)
         setIsSignedIn(true);
         setUser(res.data.data);
         return true;
@@ -123,11 +132,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
       console.log(Cookies.get("_client"),);
       console.log(Cookies.get("_uid"));
       const res = await client.delete("v1/auth/sign_out", {
-        headers: {
-          "access-token": Cookies.get("_access_token"),
-          client: Cookies.get("_client"),
-          uid: Cookies.get("_uid"),
-        },
+        headers: setAuthToHeadersFromCookies(),
       });
 
       if (res.status === 200) {
@@ -156,11 +161,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
 
     try {
       const res = await client.get("v1/auth/sessions", {
-        headers: {
-          "access-token": Cookies.get("_access_token"),
-          client: Cookies.get("_client"),
-          uid: Cookies.get("_uid"),
-        },
+        headers: setAuthToHeadersFromCookies(),
       });
       if (res?.data.isLogin === true) {
         setIsSignedIn(true);

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useState, useContext, ReactNode, useEffect } from 'react';
 import Cookies from "js-cookie";
 import client from "../api/apiClient";
+import { AxiosResponseHeaders, RawAxiosResponseHeaders } from 'axios';
 
 interface AuthContextType {
   user: User | null;
@@ -38,6 +39,12 @@ interface User {
   updatedAt: string;
 }
 
+interface AuthHeaders {
+  "access-token"?: string;
+  client?: string;
+  uid?: string;
+}
+
 // 認証用のContextを作成
 const AuthContext = createContext<AuthContextType | null>(null);
 
@@ -59,13 +66,13 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
   const [hasFetched, setHasFetched] = useState<AuthContextType["hasFetched"]>(false);
 
   //--------クッキー処理--------
-  const setAuthToCookiesFromHeaders = (headers: any) => {
+  const setAuthToCookiesFromHeaders = (headers: AxiosResponseHeaders | RawAxiosResponseHeaders): void => {
     Cookies.set("_access_token", headers["accessToken"]);
     Cookies.set("_client", headers["client"]);
     Cookies.set("_uid", headers["uid"]);
   };
 
-  const setAuthToHeadersFromCookies = () => {
+  const setAuthToHeadersFromCookies = (): Partial<AuthHeaders> => {
     return {
       "access-token": Cookies.get("_access_token"),
       client: Cookies.get("_client"),
@@ -73,7 +80,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
     };
   };
 
-  const clearAuthInCookies = () => {
+  const clearAuthInCookies = (): void => {
     Cookies.remove("_access_token");
     Cookies.remove("_client");
     Cookies.remove("_uid");

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -182,6 +182,7 @@ const AuthProvider:React.FC<{ children: ReactNode}> = ( {children} ) => {
         setUser(res?.data.data);
         console.log("ログインユーザー情報を取得しました",res?.data.data);
       } else {
+        setIsSignedIn(false);
         console.log(res?.data.data);
         console.log("ログインユーザー情報を取得できませんでした");
       }

--- a/frontend/src/components/Countdown.tsx
+++ b/frontend/src/components/Countdown.tsx
@@ -1,7 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
 import saveTimerRecord from '../api/saveTimerRecord';
+import { useAuth } from "./AuthProvider";
 
 const Countdown = () => {
+  //----------認証----------
+  const { isSignedIn } = useAuth();
+
   //----------時間----------
   //作業時間25分、休憩時間5分とする
   const workTime: number = 10 * 1000;
@@ -104,7 +108,7 @@ const Countdown = () => {
     }
     setIsCountingDown(false);
 
-    saveTimerRecord(workTimeElapsedMs, restTimeElapsedMs);
+    isSignedIn && saveTimerRecord(workTimeElapsedMs, restTimeElapsedMs);
     resetTimeElapsedMs();
   };
 
@@ -118,7 +122,7 @@ const Countdown = () => {
     setIsCountingDown(false);
     setCountdownMode(MODES.INACTIVE);
 
-    saveTimerRecord(workTimeElapsedMs, restTimeElapsedMs);
+    isSignedIn && saveTimerRecord(workTimeElapsedMs, restTimeElapsedMs);
     resetTimeElapsedMs();
   };
 
@@ -145,6 +149,8 @@ const Countdown = () => {
 
   //----------APIに経過時間を送信する----------
   useEffect(()=>{
+    if (isSignedIn === false) return;
+
     if (remainingTimeMs % (60 * 1000) === 0){
       saveTimerRecord(workTimeElapsedMs, restTimeElapsedMs);
       resetTimeElapsedMs();

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -21,6 +21,7 @@ const Home = () => {
         <>
           <Link to="/signin">サインイン</Link>
           <Link to="/signup">サインアップ</Link>
+          <p>作業時間・休憩時間を記録するには、サインインをしてください</p>
         </>
       )}
     </>

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -16,11 +16,13 @@ const Home = () => {
         <>
           <SignOut/>
           <Link to="/timer_records">記録ページ</Link>
+          <p>ログイン中</p>
         </>
       ) : (
         <>
           <Link to="/signin">サインイン</Link>
           <Link to="/signup">サインアップ</Link>
+          <p>未ログイン</p>
           <p>作業時間・休憩時間を記録するには、サインインをしてください</p>
         </>
       )}

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -5,11 +5,9 @@ import { useAuth } from "./AuthProvider";
 import SignOut from "./SignOut";
 
 const Home = () => {
-  const { isSignedIn, getCurrentUser } = useAuth();
+  const { isSignedIn } = useAuth();
 
-  useEffect(() => {
-    getCurrentUser();
-  },[isSignedIn])
+  console.log("Homeコンポーネントがレンダリングされました")
 
   return (
     <>

--- a/frontend/src/components/SignIn.tsx
+++ b/frontend/src/components/SignIn.tsx
@@ -16,8 +16,6 @@ export const SignIn = () => {
     // この時点ではまだ、user stateはnullのまま
 
     if (success) {
-      console.log("Sign-in success");
-      alert("サインインしました")
       navigate("/");
     }
   };

--- a/frontend/src/components/SignIn.tsx
+++ b/frontend/src/components/SignIn.tsx
@@ -4,6 +4,8 @@ import { useAuth } from "./AuthProvider";
 
 // サインインページを担当する（サインイン機能はAuthProviderから受けとる）
 export const SignIn = () => {
+  console.log("SignInコンポーネントがレンダリングされました")
+
   const { signIn } = useAuth();
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");

--- a/frontend/src/components/SignOut.tsx
+++ b/frontend/src/components/SignOut.tsx
@@ -11,8 +11,6 @@ export const SignOut = () => {
     const success: boolean | void = await signOut();
 
     if (success) {
-      console.log("Sign-out success");
-      alert("サインアウトしました")
       navigate("/");
     };
   };

--- a/frontend/src/components/SignUp.tsx
+++ b/frontend/src/components/SignUp.tsx
@@ -13,10 +13,6 @@ export const SignUp = () => {
   const handleSignUpSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const success: boolean | void = await signUp({ email, password, passwordConfirmation, confirmSuccessUrl });
-
-    if (success) {
-      console.log("ユーザー仮登録 success");
-    };
   };
 
   return (

--- a/frontend/src/components/SignUp.tsx
+++ b/frontend/src/components/SignUp.tsx
@@ -8,7 +8,7 @@ export const SignUp = () => {
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [passwordConfirmation, setPasswordConfirmation] = useState<string>("");
-  const confirmSuccessUrl: string = "http://localhost:3001";
+  const confirmSuccessUrl: string | undefined = process.env.REACT_APP_FRONT_SIGN_IN_URL;
 
   const handleSignUpSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/frontend/src/components/TimerRecordsList.tsx
+++ b/frontend/src/components/TimerRecordsList.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import { AxiosRequestConfig } from "axios";
 
 const TimerRecordsList = () => {
+  console.log("TimerRecordsListコンポーネントがレンダリングされました")
 
   interface TimerRecord {
     id: string;

--- a/frontend/src/routes/PrivateRoute.jsx
+++ b/frontend/src/routes/PrivateRoute.jsx
@@ -3,10 +3,27 @@ import { Navigate } from 'react-router-dom';
 import { useAuth } from '../components/AuthProvider';
 
 const PrivateRoute = ({ children }) => {
-	// ログイン中のユーザー情報を受けとる
-  const { user } = useAuth();
 
-  return user ? children : <Navigate to="/signin" />;
+  // ログイン中のユーザー情報を受けとる
+  const { user, hasFetched } = useAuth();
+  console.log("PrivateRouteコンポーネントがレンダリングされました", hasFetched, user)
+
+  // APIからUser情報を取得中は何も表示せず遷移を保留
+  if (!hasFetched) {
+    return;
+  }
+
+  // hasFetchedがtrueとなると、当コンポーネントが再レンダリングされる
+　/// user情報が取得できれば、子コンポーネントをレンダリングする
+  if (user) {
+    return <>{children}</>;
+  }
+
+  /// user情報を取得できなければ、リダイレクトする
+  if (!hasFetched && user === null) {
+    console.log("signinへリダイレクトします", hasFetched, user)
+    return <Navigate to="/signin" />;
+  }
 };
 
 export default PrivateRoute;


### PR DESCRIPTION
### 概要
デプロイ前にバグ修正や本番環境の設定を行う

close #38 

---
### 背景・目的
デプロイ前の最終チェック・修正

---
### やったこと
#### バックエンド
- [x] `letter opener web`を使用し、開発環境でメールを確認できるようにする（gmailのSMTPが使用できるか確認するため、最終的には開発環境でもgmailのSMTPを使用する）
- [x] 本番環境での`action mailer`設定をする

#### フロントエンド
- [x] `setAuthToCookiesFromHeaders、`setAuthToHeadersFromCookies`、`setAuthToHeadersFromCookies`の型を定義する
- [x] サインアウト後、クッキーから認証情報を削除する
- [x] 未サインインの場合、API通信で経過時間を記録しない
- [x] `loading`ステートの削除（代わりに`hasFetched`ステートを使用する）
- [x] `AuthProvider`で`useEffect`を使用し初回レンダリング時のみ、`getCurrentUser`を実行する
- [x] `ProviateRoute`で、`hasFetched`が`false`の時はsigninにリダイレクトさせず保留する（`hasFetched`が`true`になった時、再レンダリングをさせ、`user`ステートが存在すれば、子コンポーネントをレンダリングする。それでも`user`ステートが存在しなければsigninへリダイレクトさせる）
- [x] 認証状態を確認し、Homeページに「ログイン中」または「未ログイン中　作業時間・休憩時間を記録するには、サインインをしてください」を表示する。
- [x] クッキー処理を関数で定義する

#### 共通
- [x] ハードコードしているURLを環境変数で設定するようにする

---
### 補足
- スタイルは別イシューで実装する