### PR TITLE
ビルドコマンドに、tailwind cssのコンパイルを含める

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "npx tailwindcss -i ./src/input.css -o ./src/output.css && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
### 概要
ビルドコマンドに、tailwind cssのコンパイルを含める

close #43 

---
### 背景・目的
Renderデプロイ時に、Tailwind cssのコンパイルを実行し、output.cssを出力させるため

---
### やったこと
- [x] package.jsonのビルドコマンドを以下の通りにする
```
  "build": "npx tailwindcss -i ./src/input.css -o ./src/output.css && react-scripts build"
```
---
### 補足
