### PR TITLE
ビルドコマンドのtailwind cssの出力元ファイル名を修正

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "npx tailwindcss -i ./src/input.css -o ./src/output.css && react-scripts build",
+    "build": "npx tailwindcss -i ./src/index.css -o ./src/output.css && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
### 概要
ビルドコマンドのtailwind cssの出力元ファイル名を修正する

close #45 

---
### 背景・目的
ビルドコマンドのtailwind cssの出力元ファイル名に誤りがあった為
誤：`input.css`
正：`index.css`

---
### やったこと
- [x] package.jsonのビルドコマンドを以下の通りにする
```
  "build": "npx tailwindcss -i ./src/index.css -o ./src/output.css && react-scripts build"
```

---
### 補足
