### PR TITLE
ビルド先ディレクトリをbuildに指定する

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -49,7 +49,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./build",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
### 概要
ビルド先ディレクトリをbuildに指定する

close #47 

---
### 背景・目的
`npm run buidl`の出力先は`build`ディレクトリのため

---
### やったこと
- [x] Renderでビルド先ディレクトリを`dist`→`build`に変更
- [x] tsconfig.jsonでコンパイル先を`dist`→`build`に変更
- [x] `dist`ディレクトリを削除

---
### 補足
