### PR TITLE
バックエンドファイルをRenderにデプロイする

### DIFF
--- a/backend/bin/render-build.sh
+++ b/backend/bin/render-build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# exit on error
+set -o errexit
+
+bundle install
+bundle exec rails assets:precompile
+bundle exec rails assets:clean
+
+# If you're using a Free instance type, you need to
+# perform database migrations in the build command.
+# Uncomment the following line:
+
+bundle exec rails db:migrate

--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -1,0 +1,23 @@
+databases:
+  - name: mysite
+    databaseName: mysite
+    user: mysite
+    plan: free
+
+services:
+  - type: web
+    name: mysite
+    runtime: ruby
+    plan: free
+    buildCommand: "./bin/render-build.sh"
+    # preDeployCommand: "bundle exec rails db:migrate" # preDeployCommand only available on paid instance types
+    startCommand: "bundle exec rails server"
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: mysite
+          property: connectionString
+      - key: RAILS_MASTER_KEY
+        sync: false
+      - key: WEB_CONCURRENCY
+        value: 2 # sensible default


### PR DESCRIPTION
### 概要
バックエンドファイルをRenderにデプロイする

close #42 

---
### 背景・目的
本番環境にデプロイするため

---
### やったこと
- [x] Create a file named render-build.sh in your repo’s bin directory. Paste the following into it and save
```
#!/usr/bin/env bash
# exit on error
set -o errexit

bundle install
bundle exec rails assets:precompile
bundle exec rails assets:clean

# If you're using a Free instance type, you need to
# perform database migrations in the build command.
# Uncomment the following line:

# bundle exec rails db:migrate
```
- [x] Create a file named render.yaml at the root of your directory and paste in the YAML content below.
```
databases:
  - name: mysite
    databaseName: mysite
    user: mysite
    plan: free

services:
  - type: web
    name: mysite
    runtime: ruby
    plan: free
    buildCommand: "./bin/render-build.sh"
    # preDeployCommand: "bundle exec rails db:migrate" # preDeployCommand only available on paid instance types
    startCommand: "bundle exec rails server"
    envVars:
      - key: DATABASE_URL
        fromDatabase:
          name: mysite
          property: connectionString
      - key: RAILS_MASTER_KEY
        sync: false
      - key: WEB_CONCURRENCY
        value: 2 # sensible default


---
### 補足
