### PR TITLE
プロジェクトのルートディレクトリにrender yamlファイルを設置し、ビルドコマンドの対象ファイル（render-build…

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,7 +9,7 @@ services:
     name: mysite
     runtime: ruby
     plan: free
-    buildCommand: "./bin/render-build.sh"
+    buildCommand: "./backend/bin/render-build.sh"
     # preDeployCommand: "bundle exec rails db:migrate" # preDeployCommand only available on paid instance types
     startCommand: "bundle exec rails server"
     envVars:


### PR DESCRIPTION
### 概要
プロジェクトのルートディレクトリにrender.yamlファイルを設置する

close #50 

---
### 背景・目的
現状、`render.yaml`は`backend`ディレクトリにある。Renderはプロジェクトのルートディレクトリを探すので、移動させる

---
### やったこと
- [x] プロジェクトのルートディレクトリに`render.yaml`ファイルを設置する
- [x] ビルドコマンドの対象ファイル（`render-build.sh`）のパスを修正する

---
### 補足
