### PR TITLE
Renderでバックエンドのルートディレクトリをbackendディレクトリに指定する

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,7 +9,8 @@ services:
     name: mysite
     runtime: ruby
     plan: free
-    buildCommand: "./backend/bin/render-build.sh"
+    rootDir: backend
+    buildCommand: "./bin/render-build.sh"
     # preDeployCommand: "bundle exec rails db:migrate" # preDeployCommand only available on paid instance types
     startCommand: "bundle exec rails server"
     envVars:


### PR DESCRIPTION
### 概要
Renderでバックエンドのルートディレクトリをbackendディレクトリに指定する

close #52 

---
### 背景・目的
backendディレクトリ内にあるGemfileが見つからないというエラーが、デプロイ時発生したため

---
### やったこと
- [x] `render.yaml`で、バックエンドのルートディレクトリを`backend`ディレクトリに指定する
- [x] buildCommandのパスから、`backend`ディレクトリを削除する
```
services:
...
    rootDir: backend 
    buildCommand: "./bin/render-build.sh"
```