### PR TITLE
Fix/#56 redirect error

### DIFF
--- a/backend/app/controllers/v1/auth/confirmations_controller.rb
+++ b/backend/app/controllers/v1/auth/confirmations_controller.rb
@@ -1,0 +1,37 @@
+module V1
+  module Auth
+    class ConfirmationsController < DeviseTokenAuth::ConfirmationsController
+      def show
+        @resource = resource_class.confirm_by_token(resource_params[:confirmation_token])
+
+        if @resource.errors.empty?
+          yield @resource if block_given?
+
+          redirect_header_options = { account_confirmation_success: true }
+
+          if signed_in?(resource_name)
+            token = signed_in_resource.create_token
+            signed_in_resource.save!
+
+            redirect_headers = build_redirect_headers(token.token,
+                                                      token.client,
+                                                      redirect_header_options)
+
+            redirect_to_link = signed_in_resource.build_auth_url(redirect_url, redirect_headers)
+          else
+            redirect_to_link = DeviseTokenAuth::Url.generate(redirect_url, redirect_header_options)
+          end
+
+          # 🚀 `allow_other_host: true` を追加
+          redirect_to(redirect_to_link, allow_other_host: true)
+        else
+          if redirect_url
+            redirect_to DeviseTokenAuth::Url.generate(redirect_url, account_confirmation_success: false), allow_other_host: true
+          else
+            raise ActionController::RoutingError, 'Not Found'
+          end
+        end
+      end
+    end
+  end
+end

--- a/backend/config/initializers/devise_token_auth.rb
+++ b/backend/config/initializers/devise_token_auth.rb
@@ -63,5 +63,5 @@ DeviseTokenAuth.setup do |config|
   # devise confirmable module. If you want to use devise confirmable module and
   # send email, set it to true. (This is a setting for compatibility)
   # config.send_confirmation_email = true
-  config.redirect_whitelist = ENV.fetch("REACT_APP_FRONT_SIGN_IN_URL")
+  config.redirect_whitelist = [ENV.fetch("REACT_APP_FRONT_SIGN_IN_URL")]
 end

--- a/backend/config/initializers/devise_token_auth.rb
+++ b/backend/config/initializers/devise_token_auth.rb
@@ -63,4 +63,5 @@ DeviseTokenAuth.setup do |config|
   # devise confirmable module. If you want to use devise confirmable module and
   # send email, set it to true. (This is a setting for compatibility)
   # config.send_confirmation_email = true
+  config.redirect_whitelist = ENV.fetch("REACT_APP_FRONT_SIGN_IN_URL")
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -3,7 +3,8 @@ Rails.application.routes.draw do
   namespace :v1 do
     # 認証機能
     mount_devise_token_auth_for 'User', at: 'auth', controllers: {
-      registrations: 'v1/auth/registrations'
+      registrations: 'v1/auth/registrations',
+      confirmations: 'v1/auth/confirmations'
     }
 
     # ログインユーザー情報の取得


### PR DESCRIPTION
### 概要
異なるホスト（フロント側）へのredirectを可能にする

---
### 背景・目的
- サインアップ時に、redirectエラーが発生したため
```
Started GET "/" for 172.68.174.62 at 2025-01-20 02:10:08 +0000

Started POST "/v1/auth" for 108.162.246.102 at 2025-01-20 02:10:38 +0000
Processing by V1::Auth::RegistrationsController#create as HTML
  Parameters: {"email"=>"daichi.hirohata.japan@gmail.com", "password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]", "confirm_success_url"=>"https://pomodoro-timer-app-new.onrender.com/signin", "registration"=>{"email"=>"daichi.hirohata.japan@gmail.com", "password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]", "confirm_success_url"=>"https://pomodoro-timer-app-new.onrender.com/signin"}}
Completed 200 OK in 2952ms (Views: 0.5ms | ActiveRecord: 26.0ms | Allocations: 27630)

Started GET "/v1/auth/confirmation?config=default&confirmation_token=[FILTERED]&redirect_url=https%3A%2F%2Fpomodoro-timer-app-new.onrender.com%2Fsignin" for 108.162.246.99 at 2025-01-20 02:10:54 +0000
Processing by DeviseTokenAuth::ConfirmationsController#show as HTML
  Parameters: {"config"=>"default", "confirmation_token"=>"[FILTERED]", "redirect_url"=>"https://pomodoro-timer-app-new.onrender.com/signin"}
Redirected to 
Completed 500 Internal Server Error in 15ms (ActiveRecord: 4.2ms | Allocations: 2539)

ActionController::Redirecting::UnsafeRedirectError (Unsafe redirect to "https://pomodoro-timer-app-new.onrender.com/signin?account_confirmation_success=true", pass allow_other_host: true to redirect anyway.)

```

---
### やったこと
- [x] devise auth tokenのリダイレクト先whitelistにフロントのサインインページを追加
```
# backend/config/initializers/devise_token_auth.rb
config.redirect_whitelist = [ENV.fetch("REACT_APP_FRONT_SIGN_IN_URL")]
```
- [x] メール認証後、フロント側へのリダイレクトを許可するよう、devise auth tokenのconfirmationsControllerをオーバーライド（redirect_to メソッドに、`allow_other_host`を追記する）。ファイルは、`backend/app/controllers/v1/auth/confirmations_controller.rb`とする
- [x] `confirmations_controller.rb`へのルーティングを作成

---
### 補足
