### PR TITLE
dotenvを本番環境でも使用できるように設定

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -42,12 +42,13 @@ gem 'devise_token_auth'
 # email
 gem 'letter_opener_web'
 
+# environment variables
+gem 'dotenv-rails'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
 
-  # environment management
-  gem 'dotenv-rails'
 end
 
 group :development do


### PR DESCRIPTION
### 概要
dotenvを本番環境でも使用できるように設定

close #61 

---
### 背景・目的
AWSの本番環境でもdotenvを使用するため

---
### やったこと
- [x] Gemfile内で、dotenvを開発・テスト環境への使用限定を解除し、本番環境でも使用できるようにした 


---
### 補足
